### PR TITLE
Update .gitignore and fix Accept-Encoding header for login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
+# python
 /.venv/
 **/__pycache__/
 /dist/
 **/test*.py
 /test/
+
+# IDE files
 /.vscode/
+.idea
+
+# OS files
+.DS_Store
+Thumbs.db
+

--- a/src/core/xiaoya_login_manager.py
+++ b/src/core/xiaoya_login_manager.py
@@ -42,7 +42,7 @@ class XiaoyaLoginManager:
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
             'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Encoding': 'gzip, deflate',
         }
     
     def login(self, username, password):


### PR DESCRIPTION
### 问题： 登录失败，报错 "解析登录页面参数失败: 未能从登录页面提取到lt参数"

### 原因： `xiaoya_login_manager.py` 中的 `Accept-Encoding` 请求头包含 br (brotli) 压缩，但：

- 代码未显式依赖 brotli 包
- requests 库在无 brotli 模块时不会自动解压，而是返回乱码导致无法解析登录页面的 lt 参数
修复： 移除 Accept-Encoding 中的 br，仅保留 gzip, deflate